### PR TITLE
Add ability to maximize test runner pane

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,6 @@ Goal: run tests for any language using a plug and play system. Inspired by [vim-
 ### Supported Languages
 
 - [x] Elixir
-- [ ] JavaScript
-- [ ] Python
 - [x] Ruby (defaults to MiniTest with Rails, [can be configured with RSpec](https://github.com/anhari/vscode-test/wiki/Configure-the-ruby-test-runner-to-use-RSpec))
 
 ### Commands
@@ -18,7 +16,6 @@ Goal: run tests for any language using a plug and play system. Inspired by [vim-
 - `Run File Tests` - run all tests for the current file.
 - `Run Current Line Test` - run test on the current line.
 - `Run Last Tests` - rerun the last test command.
-- `Open Test File (deprecated)` - jump from a file to its test (i.e. `app/models/user.rb`
 - `Open Alternate File` - jump from a file to its test and vice-versa (i.e. `app/models/user.rb`
   &rarr; `test/models/user_test.rb` and `test/models/user_test.rb` &rarr; `app/models/user.rb`).
 
@@ -26,6 +23,7 @@ Goal: run tests for any language using a plug and play system. Inspired by [vim-
 
 This extension contributes the following settings:
 
+- `vscode-test.maximizeTerminal`: Maximize the test runner terminal when a command is run (default: `false`).
 - `vscode-test.rubyTestCommand`: Defines a command to use for ruby files (default: `bin/rails test`).
 - `vscode-test.rubyTestDirectory`: Defines a directory for ruby tests (default: `test`).
 - `vscode-test.rubyTestPattern`: Defines the file name pattern for ruby test files (default: `_test.rb`).
@@ -33,7 +31,7 @@ This extension contributes the following settings:
 - `vscode-test.elixirTestDirectory`: Defines a directory for elixir tests (default: `test`).
 - `vscode-test.elixirTestPattern`: Defines the file name pattern for elixir test files (default: `_test.exs`).
 
-You can specify any test settings that might be specific for a given project by defining these settings in `~your_project_root/.vscode/settings.json`.
+You can specify any test settings that might be specific for a given project by defining these settings in `~/your_project_root/.vscode/settings.json`.
 
 ## Known Issues
 

--- a/package.json
+++ b/package.json
@@ -20,8 +20,7 @@
     "onCommand:vscode-test.runFileTests",
     "onCommand:vscode-test.runLineTests",
     "onCommand:vscode-test.runLastTests",
-    "onCommand:vscode-test.openAlternateFile",
-    "onCommand:vscode-test.openTestFile"
+    "onCommand:vscode-test.openAlternateFile"
   ],
   "main": "./out/extension.js",
   "contributes": {
@@ -45,10 +44,6 @@
       {
         "command": "vscode-test.runLastTests",
         "title": "Run Last Tests"
-      },
-      {
-        "command": "vscode-test.openTestFile",
-        "title": "Open Test File (deprecated)"
       },
       {
         "command": "vscode-test.openAlternateFile",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -126,22 +126,11 @@ export const activate = (context: vscode.ExtensionContext) => {
     }
   );
 
-  let openTestFile = vscode.commands.registerCommand(
-    "vscode-test.openTestFile",
-    () => {
-      vscode.commands.executeCommand("vscode-test.openAlternateFile");
-      displayErrorMessage(
-        `vscode-test: vscode-test.openTestFile is deprecated and has been replace with vscode-test.openAlternateFile, which enables bouncing between test and source files.`
-      );
-    }
-  );
-
   context.subscriptions.push(runAllTests);
   context.subscriptions.push(runAllUnitTests);
   context.subscriptions.push(runFileTests);
   context.subscriptions.push(runLineTests);
   context.subscriptions.push(runLastTests);
-  context.subscriptions.push(openTestFile);
   context.subscriptions.push(openAlternateFile);
 };
 

--- a/src/settings/global.ts
+++ b/src/settings/global.ts
@@ -1,0 +1,15 @@
+import { getConfiguration, getBooleanSetting } from "../vscode_utils";
+
+type GlobalSettings = {
+  maximizeTerminal: boolean;
+};
+
+const getGlobalSettings = (): GlobalSettings => {
+  const config = getConfiguration();
+
+  return {
+    maximizeTerminal: getBooleanSetting(config, "maximizeTerminal") || false,
+  };
+};
+
+export { getGlobalSettings, GlobalSettings };

--- a/src/vscode_utils.ts
+++ b/src/vscode_utils.ts
@@ -1,4 +1,5 @@
 import * as vscode from "vscode";
+import { getGlobalSettings } from "./settings/global";
 
 let lastTest: string;
 const TERMINAL_NAME = "Test Runner";
@@ -23,6 +24,13 @@ const getSetting = (
   config: vscode.WorkspaceConfiguration,
   setting: string
 ): string | undefined => {
+  return config.get(setting);
+};
+
+const getBooleanSetting = (
+  config: vscode.WorkspaceConfiguration,
+  setting: string
+): boolean | undefined => {
   return config.get(setting);
 };
 
@@ -52,12 +60,18 @@ const executeTestCommand = (
   activeTextEditor: vscode.TextEditor | undefined
 ): void => {
   if (activeTextEditor) {
+    const maximizeTerminal = getGlobalSettings().maximizeTerminal;
     activeTextEditor.document.save();
     vscode.commands
       .executeCommand("workbench.action.terminal.clear")
       .then(() => {
         const terminal = findOrCreateTerminal();
         terminal.show(true);
+        if (maximizeTerminal) {
+          vscode.commands.executeCommand(
+            "workbench.action.toggleMaximizedPanel"
+          );
+        }
         terminal.sendText(command, true);
         vscode.window.showTextDocument(activeTextEditor.document);
         lastTest = command;
@@ -85,6 +99,7 @@ export {
   findOrCreateTerminal,
   getActiveTextEditor,
   getConfiguration,
+  getBooleanSetting,
   getSetting,
   executeTestCommand,
   lastTest,


### PR DESCRIPTION
- Adds the ability to maximize the test runner pane when running a test, which is a good option when working with a small amount of screen real estate or doing screencasts.
- Removes the `openTestFile` command that was deprecated in favor of `openAlternateFile`.
- Removes Python and JavaScript from the README. The checkboxes looked like bullets in certain environments. When support for either is added, we'll add them back.