### PR TITLE
Open in splits

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "onCommand:vscode-test.runFileTests",
     "onCommand:vscode-test.runLineTests",
     "onCommand:vscode-test.runLastTests",
-    "onCommand:vscode-test.openAlternateFile"
+    "onCommand:vscode-test.openAlternateFile",
+    "onCommand:vscode-test.openAlternateFileInVerticalSplit"
   ],
   "main": "./out/extension.js",
   "contributes": {
@@ -48,6 +49,10 @@
       {
         "command": "vscode-test.openAlternateFile",
         "title": "Open Alternate File"
+      },
+      {
+        "command": "vscode-test.openAlternateFileInVerticalSplit",
+        "title": "Open Alternate File (Vertical Split)"
       }
     ],
     "configuration": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -10,8 +10,11 @@ import {
   getConfiguration,
   getSetting,
 } from "./vscode_utils";
-import { rubyFileOpener } from "./openers/ruby";
-import { elixirFileOpener } from "./openers/elixir";
+import { openRubyFile, openRubyFileInVerticalSplit } from "./openers/ruby";
+import {
+  openElixirFile,
+  openElixirFileInVerticalSplit,
+} from "./openers/elixir";
 
 export const activate = (context: vscode.ExtensionContext) => {
   let config = getConfiguration();
@@ -111,10 +114,33 @@ export const activate = (context: vscode.ExtensionContext) => {
         const file = activeFile(activeTextEditor);
         switch (file.language) {
           case "ruby":
-            rubyFileOpener(file);
+            openRubyFile(file);
             break;
           case "elixir":
-            elixirFileOpener(file);
+            openElixirFile(file);
+            break;
+          default:
+            displayErrorMessage(
+              `${file.language} is unsupported by vscode-test.`
+            );
+            break;
+        }
+      }
+    }
+  );
+
+  let openAlternateFileInVerticalSplit = vscode.commands.registerCommand(
+    "vscode-test.openAlternateFileInVerticalSplit",
+    () => {
+      const activeTextEditor = getActiveTextEditor();
+      if (activeTextEditor) {
+        const file = activeFile(activeTextEditor);
+        switch (file.language) {
+          case "ruby":
+            openRubyFileInVerticalSplit(file);
+            break;
+          case "elixir":
+            openElixirFileInVerticalSplit(file);
             break;
           default:
             displayErrorMessage(

--- a/src/openers/elixir.ts
+++ b/src/openers/elixir.ts
@@ -1,4 +1,4 @@
-import { ActiveFile, openFile } from "../vscode_utils";
+import { ActiveFile, openFile, openFileInVerticalSplit } from "../vscode_utils";
 import { getElixirSettings } from "../settings/elixir";
 import {
   pathForElixirSourceFile,
@@ -17,10 +17,16 @@ const computeElixirPath = (file: ActiveFile): string => {
   return path;
 };
 
-const elixirFileOpener = (file: ActiveFile) => {
+const openElixirFile = (file: ActiveFile) => {
   if (file.workspaceRoot) {
     openFile(`${file.workspaceRoot}/${computeElixirPath(file)}`);
   }
 };
 
-export { computeElixirPath, elixirFileOpener };
+const openElixirFileInVerticalSplit = (file: ActiveFile) => {
+  if (file.workspaceRoot) {
+    openFileInVerticalSplit(`${file.workspaceRoot}/${computeElixirPath(file)}`);
+  }
+};
+
+export { computeElixirPath, openElixirFile, openElixirFileInVerticalSplit };

--- a/src/openers/ruby.ts
+++ b/src/openers/ruby.ts
@@ -1,4 +1,4 @@
-import { ActiveFile, openFile } from "../vscode_utils";
+import { ActiveFile, openFile, openFileInVerticalSplit } from "../vscode_utils";
 import { getRubySettings } from "../settings/ruby";
 import {
   pathForRubySourceFile,
@@ -15,10 +15,16 @@ const computeRubyPath = (file: ActiveFile): string => {
   }
 };
 
-const rubyFileOpener = (file: ActiveFile) => {
+const openRubyFile = (file: ActiveFile) => {
   if (file.workspaceRoot) {
     openFile(`${file.workspaceRoot}/${computeRubyPath(file)}`);
   }
 };
 
-export { computeRubyPath, rubyFileOpener };
+const openRubyFileInVerticalSplit = (file: ActiveFile) => {
+  if (file.workspaceRoot) {
+    openFileInVerticalSplit(`${file.workspaceRoot}/${computeRubyPath(file)}`);
+  }
+};
+
+export { computeRubyPath, openRubyFile, openRubyFileInVerticalSplit };

--- a/src/vscode_utils.ts
+++ b/src/vscode_utils.ts
@@ -92,6 +92,17 @@ const openFile = (path: string) => {
   );
 };
 
+const openFileInVerticalSplit = (path: string) => {
+  vscode.workspace.openTextDocument(path).then(
+    (doc) => {
+      vscode.window.showTextDocument(doc, {
+        viewColumn: vscode.ViewColumn.Beside,
+      });
+    },
+    () => displayErrorMessage(`vscode-test: File could not be found: ${path}`)
+  );
+};
+
 export {
   ActiveFile,
   activeFile,
@@ -104,4 +115,5 @@ export {
   executeTestCommand,
   lastTest,
   openFile,
+  openFileInVerticalSplit,
 };


### PR DESCRIPTION
Adds a new command for opening alternate files in vertical splits to make it easier to pull tests up side-by-side against their source files.